### PR TITLE
fix: replace copy with synchronize to skip socket files in SSH backup

### DIFF
--- a/ansible/tasks/validation.yaml
+++ b/ansible/tasks/validation.yaml
@@ -53,11 +53,12 @@
       register: ssh_key_check
 
     - name: Backup existing SSH keys if present
-      copy:
+      synchronize:
         src: "{{ ansible_env.HOME }}/.ssh/"
         dest: "{{ ansible_env.HOME }}/.mac-setup-backups/{{ ansible_date_time.date }}/ssh/"
-        remote_src: true
-        mode: preserve
+        rsync_opts:
+          - "--exclude=agent/"
+      delegate_to: localhost
       when: ssh_key_check.stat.exists
 
     - name: Display backup location


### PR DESCRIPTION
## Summary
- Replaces the Ansible `copy` module with `synchronize` (rsync) for the SSH backup task
- Excludes the `agent/` directory which contains socket files that `copy` cannot handle
- Fixes `[Errno 102] Operation not supported on socket` error that breaks all playbook runs (validation runs with `tags: always`)