### PR TITLE
feat: add quien CLI domain lookup tool

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -7,6 +7,7 @@ homebrew_taps:
   - ankitpokhrel/jira-cli
   - hashicorp/tap
   - oven-sh/bun
+  - retlehs/tap
 
 cli_packages:
   - act
@@ -59,6 +60,7 @@ cli_packages:
   - opencode
   - pnpm
   - pwgen
+  - retlehs/tap/quien
   - ripgrep
   - shellcheck
   - shortcat


### PR DESCRIPTION
## Summary

- Adds `retlehs/tap` Homebrew tap and `retlehs/tap/quien` to CLI packages
- [Quien](https://github.com/retlehs/quien) is a WHOIS/domain/IP lookup tool with an interactive TUI, RDAP-first lookups, DNS/MX/SPF/DMARC auditing, and TLS checks

## Test plan

- [ ] Run `make check` to verify the playbook parses correctly
- [ ] Run `make cli` to install and verify `quien` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)