### PR TITLE
fix: keep Homebrew node unlinked across update and cli-install flows

### DIFF
--- a/ansible/tasks/brew-unlink-node.yaml
+++ b/ansible/tasks/brew-unlink-node.yaml
@@ -1,0 +1,49 @@
+---
+# Reusable task: unlink the Homebrew `node` formula so nvm controls the
+# active Node version.
+#
+# Why this exists
+# ----------------
+# Several Homebrew formulas in `cli_packages` (agent-browser, gemini-cli,
+# opencode) declare the unversioned `node` formula as a runtime dependency.
+# The unversioned `node` formula tracks the latest major release (currently
+# Node 25.x) — not an LTS. Whenever any of these dependents is installed or
+# upgraded, Homebrew:
+#
+#   1. Installs/upgrades the `node` formula to the current latest version.
+#   2. Creates or refreshes the symlink `/opt/homebrew/bin/node` pointing
+#      at that Cellar path.
+#
+# `/opt/homebrew/bin` sits before nvm's shim in `$PATH` for non-interactive
+# shells and many tools that resolve `node` directly (pre-commit hooks,
+# CI runners, editor integrations). Result: the whole toolchain flips to
+# Node 25 whenever Homebrew decides to upgrade node, even though nvm's
+# default is Node 22 LTS.
+#
+# What unlinking does
+# -------------------
+# `brew unlink node` removes the `/opt/homebrew/bin/node` symlink only.
+# The Cellar install stays, and the keg-only path
+# `/opt/homebrew/opt/node/bin/node` continues to work — so the dependent
+# formulas (agent-browser etc.) still launch, because their shebangs
+# point at the keg path, not the PATH symlink.
+#
+# Why it needs to run in more than one place
+# ------------------------------------------
+# Homebrew re-creates the PATH symlink on any upgrade or fresh install of
+# node or its dependents. A single unlink during initial setup is undone
+# by the next `brew upgrade` (via `make update`) or the next install of a
+# node-dependent formula (via `make cli`). This task therefore runs:
+#
+#   - During node setup (ansible/tasks/node.yaml)
+#   - After cli-tools install (ansible/tasks/cli-tools.yaml)
+#   - After the update flow's `brew upgrade` (ansible/tasks/update.yaml)
+#
+# Idempotent: `brew unlink` prints "symlinks removed" only when it
+# actually removed something; `changed_when` reflects that, and
+# `failed_when: false` tolerates the "Not linked" no-op case.
+- name: Unlink Homebrew node so nvm controls the Node version
+  ansible.builtin.command: brew unlink node
+  register: brew_unlink_node_result
+  changed_when: "'symlinks removed' in brew_unlink_node_result.stdout"
+  failed_when: false

--- a/ansible/tasks/cli-tools.yaml
+++ b/ansible/tasks/cli-tools.yaml
@@ -8,6 +8,18 @@
     - productivity
     - cli
 
+# Several packages above (agent-browser, gemini-cli, opencode) pull in the
+# unversioned `node` formula as a runtime dependency and re-link
+# /opt/homebrew/bin/node → whatever major version brew currently ships
+# (Node 25.x at time of writing). Unlink here so nvm's LTS controls the
+# active Node version. See brew-unlink-node.yaml for full context.
+- name: Unlink Homebrew node after cli package installs
+  ansible.builtin.import_tasks: brew-unlink-node.yaml
+  tags:
+    - install
+    - productivity
+    - cli
+
 - name: Install agent-browser Chromium
   ansible.builtin.shell: agent-browser install
   args:

--- a/ansible/tasks/node.yaml
+++ b/ansible/tasks/node.yaml
@@ -6,17 +6,10 @@
     - install
     - node
 
-# Some Homebrew packages (e.g. agent-browser, gemini-cli, opencode) depend on
-# the Homebrew `node` formula. Homebrew auto-installs it, placing a `node`
-# symlink in /opt/homebrew/bin/ which takes priority over nvm in PATH.
-# This causes `nvm use` and .nvmrc files to have no effect — the system
-# always resolves to whichever node version Homebrew installed.
-# Unlinking removes the symlink while keeping node available to its dependents.
-- name: Unlink Homebrew node so nvm controls the node version
-  ansible.builtin.command: brew unlink node
-  register: brew_unlink_result
-  changed_when: "'symlinks removed' in brew_unlink_result.stdout"
-  failed_when: false
+# See brew-unlink-node.yaml for why this is needed and why the unlink
+# also runs in cli-tools.yaml and update.yaml.
+- name: Unlink Homebrew node so nvm controls the Node version
+  ansible.builtin.import_tasks: brew-unlink-node.yaml
   tags:
     - install
     - node

--- a/ansible/tasks/update.yaml
+++ b/ansible/tasks/update.yaml
@@ -19,6 +19,14 @@
       register: cask_upgrade
       ignore_errors: yes  # Some casks may fail if app is running
 
+    # `brew upgrade` above will have re-linked the unversioned `node`
+    # formula (pulled in as a dep of agent-browser, gemini-cli, opencode)
+    # to whatever current major release brew ships. That silently flips
+    # `/opt/homebrew/bin/node` to Node 25.x, overriding nvm's LTS.
+    # Re-unlink so nvm keeps control. See brew-unlink-node.yaml.
+    - name: Unlink Homebrew node after brew upgrade
+      ansible.builtin.import_tasks: brew-unlink-node.yaml
+
     - name: Clean up Homebrew
       command: brew cleanup -s
       changed_when: true


### PR DESCRIPTION
## Problem

Running `brew unlink node` manually doesn't stick — a few hours or days later, `/opt/homebrew/bin/node` is back, pointing at the latest Node major (currently 25.x). Any tool resolving `node` directly through `\$PATH` (Claude Code shell, pre-commit hooks, CI runners that don't source `.zshrc`) gets Node 25, bypassing nvm's LTS.

## Root cause

Three Homebrew formulas in `cli_packages` declare the **unversioned** `node` formula as a runtime dependency:

- `agent-browser`
- `gemini-cli`
- `opencode`

Homebrew's unversioned `node` formula tracks the current latest major release (Node 25.x at time of writing, not the LTS). Whenever any of these dependents is installed or upgraded, Homebrew:

1. Installs/upgrades the `node` formula to current latest.
2. Creates or refreshes the `/opt/homebrew/bin/node` symlink into the Cellar.

The existing `ansible/tasks/node.yaml` ran `brew unlink node` exactly **once** during initial node setup. But three subsequent flows re-link it:

| Flow | What re-links node |
|------|--------------------|
| `make update` | `brew upgrade` refreshes the node formula + re-creates the PATH symlink |
| `make cli` / `make install` | Installing agent-browser/gemini-cli/opencode pulls `node` in as a dep |
| Manual `brew upgrade <dependent>` | Same mechanism (out of scope for this repo) |

So every time one of these paths was taken, the user was quietly flipped back to Node 25 — even though `nvm alias default` was set to `lts/*`.

## Fix

Extract the unlink into a reusable task (`ansible/tasks/brew-unlink-node.yaml`) with full context on why it's needed, and import it after every brew operation that can re-link node:

- **`ansible/tasks/node.yaml`** — initial setup (existing, now via import).
- **`ansible/tasks/cli-tools.yaml`** — after `brew install` of `cli_packages`. Covers `make cli` and the install portion of `make`.
- **`ansible/tasks/update.yaml`** — after `brew upgrade` completes. Covers `make update`.

## Why this is safe

`brew unlink node` removes only `/opt/homebrew/bin/node` (the PATH symlink). The Cellar install (`/opt/homebrew/Cellar/node/…`) and the keg-only path (`/opt/homebrew/opt/node/bin/node`) remain intact. The dependents (agent-browser, gemini-cli, opencode) continue to launch because their shebangs point at the keg path — verified:

\`\`\`
\$ file /opt/homebrew/bin/agent-browser
/opt/homebrew/bin/agent-browser: a /opt/homebrew/opt/node/bin/node script text executable
\`\`\`

## Idempotency

\`brew unlink node\` when node is already unlinked prints \"Not linked\" (no-op). The task's \`changed_when\` only fires on the \"symlinks removed\" string, so re-runs stay quiet. \`failed_when: false\` tolerates the no-op case without failing the play.

## Out of scope

- **Manual `brew upgrade`** outside the ansible flows — user still needs to run `make update` (or `make node`) afterwards. A post-brew-command shell hook would be more automatic but belongs in the dotfiles repo, not here.
- **Replacing `node` with `node@22`** — the three dependent formulas hard-code the unversioned `node` dep, so brew would install unversioned `node` anyway. Unlinking is the right lever.

## Verification

- `ansible-playbook local.yaml --syntax-check` — passes.
- `ansible-playbook update.yaml --syntax-check` — passes.

## Test plan

- [ ] `make update` — verify `/opt/homebrew/bin/node` is not present after the run.
- [ ] Install a fresh node-dependent cli package and re-run `make cli` — verify unlink happens.
- [ ] `make node` — verify unlink + nvm LTS install still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)