### PR TITLE
feat: add Zed code editor to GUI packages

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -126,6 +126,7 @@ gui_packages:
   - vlc
   - waves-central
   - wezterm
+  - zed
   - zoom
 
 gui_packages_personal:
@@ -146,7 +147,6 @@ gui_packages_to_remove_if_installed:
   - ngrok
   - orbstack
   - rewind
-  - zed
   - zotero
 
 gui_packages_to_remove_if_installed_work:


### PR DESCRIPTION
## Summary

- Adds the [Zed](https://zed.dev) code editor to the `gui_packages` list so it gets installed via Homebrew Cask on both personal and work machines
- Removes `zed` from the `gui_packages_to_remove_if_installed` list where it was previously marked for uninstallation