### PR TITLE
feat: add codex CLI to GUI packages

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -92,6 +92,7 @@ gui_packages:
   - chatgpt
   - claude
   - claude-code
+  - codex
   - cursor
   - deskpad
   - devtoys


### PR DESCRIPTION
## Summary
- Add OpenAI's `codex` coding agent to `gui_packages`
- Installed via Homebrew cask, matching the precedent set for `claude-code` in #71 / 7282b4b

## Test plan
- [ ] `make gui` installs codex without other regressions
- [ ] `codex --version` works after install
- [ ] Stale-brew note: cask DSL recently added `generate_completions_from_executable` shells; if `brew update` hasn't run, the cask currently errors locally. The playbook does `brew update` before installs and the cask task uses `ignore_errors: true`, so it shouldn't break the run — but worth confirming codex actually landed after the next `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)