### PR TITLE
fix: trust third-party Homebrew taps so brew bundle doesn't block setup

### DIFF
--- a/ansible/tasks/brew-trust-taps.yaml
+++ b/ansible/tasks/brew-trust-taps.yaml
@@ -1,0 +1,52 @@
+---
+# Reusable task: trust the non-official Homebrew taps declared in the
+# Brewfiles so `brew bundle` / `brew upgrade` can load their formulae.
+#
+# Why this exists
+# ----------------
+# Homebrew 6.0+ added a tap-trust gate (HOMEBREW_REQUIRE_TAP_TRUST).
+# When that gate is active, Homebrew refuses to load a formula from a
+# third-party tap until the tap is explicitly trusted, failing with:
+#
+#   Warning: Cannot check whether hashicorp/tap/terraform is outdated
+#   because its tap is not trusted.
+#   Error: Refusing to load formula hashicorp/tap/terraform from
+#   untrusted tap hashicorp/tap.
+#
+# `brew bundle` runs `brew update` first, which can upgrade Homebrew
+# itself and flip this gate on part-way through a `make` run, so the
+# failure can appear even on a machine that installed fine before. The
+# Brewfiles pull formulae from several third-party taps (hashicorp/tap,
+# oven-sh/bun, retlehs/tap, ankitpokhrel/jira-cli), so a single
+# untrusted tap aborts the whole CLI install.
+#
+# What this does
+# --------------
+# Reads every `tap "..."` line from the repo's Brewfiles and runs
+# `brew trust --taps <tap>` for each. Trust is recorded in
+# ~/.homebrew/trust.json and persists, so trusting here once also keeps
+# `make update` (which upgrades the same tap formulae) from being blocked.
+#
+# Why it needs to run in more than one place
+# ------------------------------------------
+# The trust gate blocks both installs and upgrades, and a fresh machine
+# may run `make update` before ever running a full install. This task
+# therefore runs:
+#
+#   - Before the cli-tools `brew bundle` (ansible/tasks/cli-tools.yaml)
+#   - Before the update flow's `brew upgrade` (ansible/tasks/update.yaml)
+#
+# Idempotent: `brew trust` prints "Trusted tap:" only when it adds a new
+# entry and "Already trusted tap:" otherwise, so changed_when reflects a
+# real change. Trusting a tap is harmless even when the gate is inactive.
+# The leading `set -euo pipefail` ensures a genuine `brew trust` error
+# still fails the task.
+- name: Trust non-official Homebrew taps declared in the Brewfiles
+  ansible.builtin.shell: |
+    set -euo pipefail
+    for tap in $(awk '/^tap "/{gsub(/"/, "", $2); print $2}' "{{ playbook_dir }}"/Brewfile.* | sort -u); do
+      brew trust --taps "$tap"
+    done
+  environment: "{{ homebrew_environment }}"
+  register: brew_trust_taps_result
+  changed_when: "'Trusted tap:' in brew_trust_taps_result.stdout"

--- a/ansible/tasks/cli-tools.yaml
+++ b/ansible/tasks/cli-tools.yaml
@@ -1,3 +1,14 @@
+# Homebrew 6.0+ refuses to load formulae from untrusted third-party taps
+# (hashicorp/tap, oven-sh/bun, retlehs/tap, ankitpokhrel/jira-cli) when its
+# tap-trust gate is active, which aborts the bundle below. Trust the taps
+# first. See brew-trust-taps.yaml for full context.
+- name: Trust third-party Homebrew taps before cli package installs
+  ansible.builtin.import_tasks: brew-trust-taps.yaml
+  tags:
+    - install
+    - productivity
+    - cli
+
 - name: Install CLI packages from Brewfile
   ansible.builtin.command: brew bundle --file "{{ playbook_dir }}/Brewfile.cli"
   environment: "{{ homebrew_environment }}"

--- a/ansible/tasks/dotfiles.yaml
+++ b/ansible/tasks/dotfiles.yaml
@@ -144,6 +144,11 @@
     - stow
     - cli
 
+# install-claude.sh pulls skills from several external repos. A single
+# upstream source going bad (e.g. a repo restructured without SKILL.md)
+# makes the script exit non-zero, which would otherwise abort the whole
+# `make` run over an optional, best-effort step. Treat it as non-fatal and
+# surface a warning instead so setup completes.
 - name: Install Claude framework for multiple coding agents
   ansible.builtin.shell: |
     export NVM_DIR="{{ ansible_env.HOME }}/.nvm"
@@ -152,7 +157,23 @@
   args:
     chdir: "{{ ansible_env.HOME }}/.dotfiles"
     executable: /bin/bash
+  register: claude_framework_result
   changed_when: true
+  failed_when: false
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+
+- name: Warn if the Claude framework installer reported a problem
+  ansible.builtin.debug:
+    msg: >-
+      install-claude.sh exited with rc={{ claude_framework_result.rc }}.
+      Setup continued because this step is best-effort (usually a flaky
+      upstream skill source). Re-run `make dotfiles` later, or check the
+      installer output above.
+  when: claude_framework_result.rc | default(0) != 0
   tags:
     - install
     - dotfiles

--- a/ansible/tasks/update.yaml
+++ b/ansible/tasks/update.yaml
@@ -9,6 +9,12 @@
       environment: "{{ homebrew_environment }}"
       register: brew_update
 
+    # Updating Homebrew can flip on its tap-trust gate, after which
+    # `brew upgrade` refuses to load outdated formulae from third-party
+    # taps. Trust the taps first. See brew-trust-taps.yaml for context.
+    - name: Trust third-party Homebrew taps before upgrading
+      ansible.builtin.import_tasks: brew-trust-taps.yaml
+
     - name: Upgrade all Homebrew packages
       community.general.homebrew:
         upgrade_all: yes


### PR DESCRIPTION
## Summary

- `make` failed at **Install CLI packages from Brewfile** with `Refusing to load formula hashicorp/tap/terraform from untrusted tap`. Homebrew 6.0+ added a tap-trust gate (`HOMEBREW_REQUIRE_TAP_TRUST`); because `brew bundle` runs `brew update` first, Homebrew can upgrade itself and flip the gate on mid-run, then refuse to load formulae from untrusted third-party taps (`hashicorp/tap`, `oven-sh/bun`, `retlehs/tap`, `ankitpokhrel/jira-cli`) — aborting the whole CLI install.
- Add reusable `ansible/tasks/brew-trust-taps.yaml` that trusts every tap declared in the Brewfiles (idempotent; auto-covers future taps), and run it before `brew bundle` (cli-tools) and before `brew upgrade` (update flow).
- Make the best-effort **Install Claude framework** task non-fatal: a broken upstream skill source was the *next* thing to abort the run once the tap issue was cleared. It now warns instead of failing the whole `make`.

## Verification

- `ansible-playbook local.yaml --syntax-check` passes.
- `ansible-playbook local.yaml --tags cli` now completes with `failed=0`: the Brewfile install succeeds and the Claude framework step logs a warning rather than stopping the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)