### PR TITLE
feat: add Handy speech-to-text app to GUI packages

### DIFF
--- a/Brewfile.gui
+++ b/Brewfile.gui
@@ -17,6 +17,7 @@ cask "firefox", greedy: true
 cask "ghostty", greedy: true
 cask "google-chrome", greedy: true
 cask "granola", greedy: true
+cask "handy", greedy: true
 cask "hiddenbar", greedy: true
 cask "httpie-desktop", greedy: true
 cask "imageoptim", greedy: true


### PR DESCRIPTION
## Summary
- Adds [Handy](https://github.com/cjpais/handy), the open-source offline speech-to-text app, to `Brewfile.gui` via its official Homebrew cask (`handy`)
- Installs for both personal and work profiles as part of `make gui` / `make install`

## Notes
- Cask comes from the core `homebrew-cask` tap, so no new taps are needed
- `greedy: true` matches the convention used for all other casks (Handy auto-updates)
- Verified `brew bundle list --file=Brewfile.gui --casks` parses and lists `handy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)