### PR TITLE
feat: install Pi coding agent

### DIFF
--- a/ansible/tasks/node.yaml
+++ b/ansible/tasks/node.yaml
@@ -50,7 +50,7 @@
     export PNPM_HOME="{{ ansible_env.HOME }}/Library/pnpm"
     export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
     source "$(brew --prefix nvm)/nvm.sh"
-    pnpm add -g {{ item }}@latest
+    pnpm add -g --ignore-scripts {{ item }}@latest
   args:
     executable: /bin/bash
   loop: "{{ pnpm_global_packages | default([]) }}"

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -33,4 +33,5 @@ gui_packages_to_remove_if_installed_work:
   - protonvpn
 
 pnpm_global_packages:
+  - "@earendil-works/pi-coding-agent"
   - task-master-ai


### PR DESCRIPTION
## Summary

- add `@earendil-works/pi-coding-agent` to the shared pnpm global packages
- install global pnpm packages with `--ignore-scripts`, matching Pi's official install guidance

## Impact

`make node` and the normal install flow now install or update the `pi` CLI for both personal and work profiles.

## Validation

- `ANSIBLE_LOCAL_TEMP=/tmp/... ansible-playbook local.yaml --syntax-check`
- isolated `pnpm add -g --ignore-scripts @earendil-works/pi-coding-agent@latest`
- isolated `pi --version` returned `0.83.0`
- `git diff --check`

Known baseline: focused `ansible-lint ansible/tasks/node.yaml` still reports the file's two existing `no-changed-when` findings.
