### PR TITLE
feat: install GitHub Stack extension

### DIFF
--- a/ansible/tasks/cli-tools.yaml
+++ b/ansible/tasks/cli-tools.yaml
@@ -30,6 +30,16 @@
   retries: 1
   delay: 5
 
+- name: Install GitHub Stack extension
+  ansible.builtin.command: gh extension install github/gh-stack
+  args:
+    creates: "{{ ansible_env.HOME }}/.local/share/gh/extensions/gh-stack"
+  tags:
+    - install
+    - productivity
+    - cli
+    - gh-stack
+
 # Several CLI packages above (agent-browser, gemini-cli, opencode) pull in the
 # unversioned `node` formula as a runtime dependency and re-link
 # /opt/homebrew/bin/node → whatever major version brew currently ships


### PR DESCRIPTION
## Summary

- install `github/gh-stack` through the repository's Ansible CLI setup
- keep repeated setup runs idempotent with an Ansible `creates` guard

## Why

Fresh machines and existing machines running the setup should receive `gh-stack` without requiring an ad-hoc manual install.

## Validation

- `ansible-playbook local.yaml --syntax-check`
- targeted `--tags gh-stack` run installed the extension
- a second targeted run completed with `changed=0`
- `gh stack --help` succeeds
