### PR TITLE
feat(herdr): install agent state integrations for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ make update
 | `make osx` | Configure macOS system preferences |
 | `make dock` | Configure dock items |
 | `make dotfiles` | Sync dotfiles from repository |
+| `make herdr` | Install the Herdr agent-state integrations (Claude Code, Codex) |
 | `make git` | Configure git identity, aliases, and GPG signing |
 | `make fonts` | Install developer fonts |
 | `make themes` | Install terminal themes |
@@ -85,6 +86,30 @@ make update
 - **AI Assistants**: ChatGPT, Claude
 - **AI Development**: Ollama for local LLMs
 - **API Testing**: Bruno, Postman, HTTPie
+- **Agent Workspace**: [Herdr](https://herdr.dev), with per-agent state integrations (see below)
+
+#### Herdr agent state
+
+Herdr is a terminal workspace manager whose sidebar shows what each coding agent
+is doing — working, blocked, idle — which is what makes several concurrent agents
+legible at a glance.
+
+Left alone, Herdr infers that state by pattern-matching the terminal screen, so it
+breaks whenever an agent changes how it renders. `make herdr` installs a per-agent
+integration instead, and the agent reports its own state over the Herdr socket.
+The agents covered are listed in `herdr_integrations` in `defaults.yaml`; run
+`herdr integration install --help` to see every supported target.
+
+The hook scripts are versioned with the herdr binary, so they are installed by
+`herdr integration install` rather than checked into the dotfiles repo, where they
+would go stale on every upgrade. Herdr owns what it writes into
+`~/.claude/settings.json` and `~/.codex/`. Herdr's own configuration is a stow
+package in the dotfiles repo.
+
+This runs after the dotfiles task on purpose: that task copies
+`claude/.claude/settings.json` over `~/.claude/settings.json`, which drops the
+hook registration the Claude integration adds there. Running afterwards restores
+it on every converge.
 
 ### System Enhancements
 - **Window Management**: Karabiner Elements

--- a/ansible/tasks/herdr.yaml
+++ b/ansible/tasks/herdr.yaml
@@ -1,0 +1,90 @@
+# Herdr (https://herdr.dev) is the terminal workspace manager installed from
+# Brewfile.cli. Its sidebar shows each coding agent's state — working, blocked,
+# idle — which is what makes several concurrent agents legible at a glance.
+#
+# Without a per-agent integration Herdr infers that state by pattern-matching
+# the terminal screen (a spinner glyph in the window title, for example), which
+# breaks whenever an agent changes how it renders. With one installed, the agent
+# reports its own state over the Herdr socket instead.
+#
+# The hook scripts are versioned with the herdr binary, so this delegates to
+# `herdr integration install` rather than vendoring copies into .dotfiles that
+# would go stale on every herdr upgrade. Herdr owns the registration it writes
+# into ~/.claude/settings.json and ~/.codex/{hooks.json,config.toml}.
+#
+# ORDERING: this file is imported after dotfiles.yaml on purpose. That task
+# copies claude/.claude/settings.json over ~/.claude/settings.json, which drops
+# the SessionStart entry the Claude integration registers there. Running
+# afterwards puts it back on every converge.
+
+- name: Check whether herdr is installed
+  ansible.builtin.command: command -v herdr
+  register: herdr_binary
+  changed_when: false
+  failed_when: false
+  tags:
+    - install
+    - cli
+    - herdr
+
+- name: Report herdr integration status
+  ansible.builtin.command: herdr integration status
+  register: herdr_integration_status
+  changed_when: false
+  failed_when: false
+  when: herdr_binary.rc == 0
+  tags:
+    - install
+    - cli
+    - herdr
+
+# `herdr integration install <agent>` refuses to run until the agent's own
+# config directory exists, so on a fresh machine this can legitimately have
+# nothing to do yet. Treated as best-effort for the same reason install-claude.sh
+# is: an optional convenience should never abort a whole `make` run.
+- name: Install herdr agent state integrations
+  ansible.builtin.command: "herdr integration install {{ item }}"
+  loop: "{{ herdr_integrations | default([]) }}"
+  register: herdr_integration_install
+  changed_when: true
+  failed_when: false
+  # The search expression must stay quoted: the `: ` inside it would otherwise
+  # make YAML parse this list entry as a mapping, which Ansible then treats as
+  # unconditionally true and the task loses its idempotency.
+  when:
+    - herdr_binary.rc == 0
+    - herdr_integration_status.stdout is defined
+    - "herdr_integration_status.stdout is search(item ~ ': not installed')"
+  tags:
+    - install
+    - cli
+    - herdr
+
+- name: Warn if a herdr integration could not be installed
+  ansible.builtin.debug:
+    msg: >-
+      herdr integration install {{ item.item }} exited with rc={{ item.rc }}.
+      Setup continued because this step is best-effort — usually the agent's
+      config directory does not exist yet. Install the agent, then re-run
+      `make herdr`.
+  loop: "{{ herdr_integration_install.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('') }}"
+  when:
+    - item.skipped is not defined
+    - item.rc | default(0) != 0
+  tags:
+    - install
+    - cli
+    - herdr
+
+- name: Note that herdr is not installed
+  ansible.builtin.debug:
+    msg: >-
+      herdr was not found on PATH, so its agent integrations were skipped.
+      It is declared in Brewfile.cli — run `make cli` first, then `make herdr`.
+  when: herdr_binary.rc != 0
+  tags:
+    - install
+    - cli
+    - herdr

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -12,10 +12,17 @@ dotfiles_stow_packages:
   - .oh-my-zsh
   - karabiner
   - ghostty
+  - herdr
 
 claude_installer_agents:
   - codex
 claude_installer_with_opencode: true
+
+# Coding agents that report their state to the Herdr sidebar via a hook.
+# `herdr integration install --help` lists every supported target.
+herdr_integrations:
+  - claude
+  - codex
 
 cli_packages_to_remove_if_installed:
   - neofetch

--- a/local.yaml
+++ b/local.yaml
@@ -31,6 +31,7 @@
     - import_tasks: ansible/tasks/node.yaml
     - import_tasks: ansible/tasks/gpg.yaml
     - import_tasks: ansible/tasks/dotfiles.yaml
+    - import_tasks: ansible/tasks/herdr.yaml
     - import_tasks: ansible/tasks/rust.yaml
     - import_tasks: ansible/tasks/remove-unwanted-packages.yaml
     - import_tasks: ansible/tasks/dock.yaml

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps personal work dock setup keys cli gui update check gpg gpg-setup work-remove permissions
+.PHONY: all deps personal work dock setup keys cli gui update check gpg gpg-setup work-remove permissions herdr
 
 WITH_SUDO_ASKPASS = scripts/with-sudo-askpass.sh
 
@@ -13,6 +13,9 @@ permissions:
 
 dotfiles:
 	@ansible-playbook local.yaml --tags dotfiles
+
+herdr:
+	@ansible-playbook local.yaml --tags herdr
 
 deps:
 	@echo "Installing dependencies..."


### PR DESCRIPTION
## Why

[Herdr](https://herdr.dev) is the terminal workspace manager already installed from `Brewfile.cli`. Its sidebar shows what each coding agent is doing — working, blocked, idle — which is what makes several concurrent agents legible at a glance.

Nothing was installing its per-agent integrations, so on this machine all fourteen were absent. Herdr was falling back to inferring agent state by pattern-matching the terminal screen. Concretely, `herdr agent explain` showed it classifying a live Claude session as "working" by matching the regex `^[⠀-⣿] ` against the braille spinner glyph in the window title — correct at that instant, but it breaks the moment an agent changes how it renders.

With an integration installed, the agent reports its own state over the Herdr socket instead.

## What changed

- **`ansible/tasks/herdr.yaml`** — installs the integrations listed in `herdr_integrations`, guarded on the herdr binary being present and gated on `herdr integration status` so it is a no-op once installed
- **`defaults.yaml`** — `herdr_integrations: [claude, codex]`, plus `herdr` added to `dotfiles_stow_packages`
- **`local.yaml`** — imports the new task after `dotfiles.yaml`
- **`makefile`** — `make herdr` target
- **`README.md`** — command table entry and a section explaining the ordering constraint

## Two design decisions worth reviewing

**Delegating rather than vendoring.** The hook scripts are versioned with the herdr binary, so a copy checked into `.dotfiles` would go stale on every upgrade. This calls `herdr integration install` and lets Herdr own what it writes into `~/.claude/settings.json` and `~/.codex/{hooks.json,config.toml}`.

**Import order matters.** `dotfiles.yaml` copies `claude/.claude/settings.json` over `~/.claude/settings.json`, which drops the `SessionStart` entry the Claude integration registers there. This task is imported *after* it so the registration is restored on every converge. Moving the import earlier would silently break Claude state reporting.

Note that Claude Code's integration provides session identity but not the full lifecycle, so Herdr still uses screen detection for some Claude state. Codex is not documented with that caveat.

## Testing

`ansible-playbook local.yaml --syntax-check` passes.

The `when` condition was verified against real `herdr integration status` output with a throwaway playbook: with neither installed, both `claude` and `codex` are selected; with `claude` already installed, only `codex` is.

That check earned its keep — it caught a real bug in the first version. Written unquoted, the list entry

```yaml
- herdr_integration_status.stdout is search(item ~ ': not installed')
```

is parsed by YAML as a *mapping*, because the `: ` sits inside a quote that does not start the scalar. Ansible then evaluates the resulting dict as unconditionally true and the task loses its idempotency. Quoting the whole expression fixes it; there is a comment in the task so it does not regress. Confirmed all three conditions now parse as `str`.

Not run against this machine — the integrations install when you run `make herdr` after merge.

## Merge order

Land citypaul/.dotfiles#220 first — it adds the `herdr` stow package that `dotfiles_stow_packages` here now references. `stow herdr` fails if the package does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)