### PR TITLE
fix(herdr): back up an existing herdr config before stowing

### DIFF
--- a/ansible/tasks/dotfiles.yaml
+++ b/ansible/tasks/dotfiles.yaml
@@ -127,7 +127,8 @@
     moved=false
     for target in \
       "{{ ansible_env.HOME }}/.zshrc" \
-      "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty/config"
+      "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty/config" \
+      "{{ ansible_env.HOME }}/.config/herdr/config.toml"
     do
       backup="${target}.old"
       if [ -f "$target" ] && [ ! -L "$target" ] && [ ! -f "$backup" ]; then


### PR DESCRIPTION
## The bug

#90 added `herdr` to `dotfiles_stow_packages`. That is not enough on a machine that already has a hand-written `~/.config/herdr/config.toml` — which is exactly the case here, since capturing that file was the point.

GNU stow refuses to overwrite a real file, and it aborts the **entire invocation** rather than skipping the one package:

```
WARNING! stowing herdr would cause conflicts:
  * cannot stow ../repo/herdr/.config/herdr/config.toml over existing target
    .config/herdr/config.toml since neither a link nor a directory and
    --adopt not specified
All operations aborted.
```

Because `dotfiles.yaml` stows every package in one `stow {{ dotfiles_stow_packages | join(' ') }}` call, one pre-existing herdr config would stop `zsh`, `tmux`, `gnupg`, `alacritty`, `zellij`, `karabiner` and `ghostty` from stowing as well. `make dotfiles` would leave the machine unstowed.

This was latent — nobody had run `make dotfiles` since #90 merged, so it had not fired yet.

## The fix

Add the herdr config to the pre-stow backup loop that already handles `~/.zshrc` and the ghostty config. One line, same mechanism, same guard.

The existing condition (`-f` and not `-L` and no prior `.old`) keeps it idempotent: a real file is moved aside once, and later runs do nothing because the target is a symlink by then.

## Verification

Against GNU Stow 2.4.1, in a throwaway tree:

1. **Reproduced the failure** — with a real `config.toml` present, `stow fakezsh herdr` aborted and the non-conflicting `fakezsh` package was left unlinked, confirming one conflict takes down the whole run.
2. **Confirmed the fix** — running the backup loop first moved the file to `config.toml.old`, after which both packages linked correctly.
3. **Confirmed idempotency** — an immediate second `stow` produced no output and no changes.

`ansible-playbook local.yaml --syntax-check` passes.

## After merge

`make dotfiles` will move the current `~/.config/herdr/config.toml` to `config.toml.old` and replace it with a symlink into the repo. The effective settings are unchanged — the repo copy has the same `agent_panel_sort = "priority"` plus explanatory comments — so Herdr's behaviour does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)