### PR TITLE
docs(herdr): document the Codex hook trust prompt and its timing trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,49 @@ This runs after the dotfiles task on purpose: that task copies
 hook registration the Claude integration adds there. Running afterwards restores
 it on every converge.
 
+##### Codex needs a one-time trust prompt (not automated, deliberately)
+
+Installing the integration is not sufficient for Codex. Codex gates hooks behind
+a trust prompt, because a hook can run outside its sandbox. The first Codex
+launch after `make herdr` shows:
+
+```
+Hooks need review
+Hooks can run outside the sandbox after you trust them.
+  > Trust all and continue
+    Review hooks
+    Continue without trusting (hooks won't run)
+```
+
+Choose **Trust all and continue**. Codex records the decision in
+`~/.codex/config.toml`:
+
+```toml
+[hooks.state."/Users/<you>/.codex/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:..."
+```
+
+**Trusting is too late for the session you are in.** The hook is a `SessionStart`
+hook, so it has already been skipped by the time you answer the prompt. Restart
+that Codex pane once more and the state reporting begins.
+
+This step is deliberately left manual. The `trusted_hash` is a sha256 over an
+internal Codex representation of the hook — not over `hooks.json`, the hook
+script, the command string, or the JSON entry, all four of which were tested and
+none match — so Ansible cannot pre-seed it reliably. It would also change on
+every herdr integration bump and potentially on Codex releases. And pre-seeding
+it would defeat the point: the prompt is consent for a script to run outside the
+sandbox, which is a decision worth making rather than baking into a repo.
+
+Claude Code has no equivalent gate; its hook works as soon as the session
+restarts.
+
+Verify either agent with:
+
+```bash
+herdr agent list   # a reporting pane has a populated agent_session
+```
+
 ### System Enhancements
 - **Window Management**: Karabiner Elements
 - **System Monitoring**: Stats, glances, htop


### PR DESCRIPTION
## Why

Installing the Codex integration is not sufficient on its own, and the failure mode is silent.

Codex gates hooks behind a trust prompt, because a hook can run outside its sandbox. Until that prompt is answered the hook never runs — while `herdr integration status` cheerfully reports `codex: current (v6)` throughout, so nothing indicates a problem.

There is a second trap behind the first. The herdr hook is a `SessionStart` hook, so by the time the prompt appears it has **already been skipped for that session**. Trust gets recorded, the pane carries on using screen detection, and it looks like the integration simply doesn't work.

That is exactly what happened here. Timestamps from the machine:

```
codex process started   20:50:53
trust written           20:51:07   <- 14 seconds too late for that session
```

The pane still showed `agent_session: null` and `matched_rule: osc_title_idle` afterwards. Everything was configured correctly — `hooks.json` well-formed, `[features] hooks = true`, script executable, `HERDR_ENV`/`HERDR_PANE_ID`/`HERDR_SOCKET_PATH` all present in the process environment. It just needed one more restart.

## What this adds

A subsection under the existing Herdr docs covering:

- the exact prompt wording and which option to pick
- the `[hooks.state."..."]` / `trusted_hash` entry it writes to `~/.codex/config.toml`
- **the required second restart**, which is the part that costs time
- how to verify, via a populated `agent_session` in `herdr agent list`
- that Claude Code has no equivalent gate

## Why this is documented rather than automated

I checked whether `make herdr` could pre-seed the trust entry so a new Mac would need no manual step. It can't, reliably:

- The `trusted_hash` is a sha256 over an internal Codex representation. I tested the four plausible inputs — the whole `hooks.json`, the hook script contents, the command string, and the compact JSON of the hook entry — and **none** match the stored hash. Reproducing it means tracking Codex's internal serialization.
- It is content-bound, so it churns on every herdr integration bump (v6 → v7) and potentially on Codex releases.
- The format is internal (`tui/src/startup_hooks_review.rs`) and undocumented, so it could change silently between releases.
- Most importantly, the prompt is consent for a script to run outside the sandbox. Pre-seeding it from a repo defeats the control rather than satisfying it.

A one-time prompt per hook change is the right trade. Documenting it so it isn't mistaken for a broken integration is the useful part.

## Related

- citypaul/mac-dev-machine-setup#91 — the stow conflict fix (still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)