### PR TITLE
feat(herdr): make `make herdr` set up Herdr completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ make update
 | `make osx` | Configure macOS system preferences |
 | `make dock` | Configure dock items |
 | `make dotfiles` | Sync dotfiles from repository |
-| `make herdr` | Install the Herdr agent-state integrations (Claude Code, Codex) |
+| `make herdr` | Set up Herdr completely: state integrations, the agent skill, and the stowed config |
 | `make git` | Configure git identity, aliases, and GPG signing |
 | `make fonts` | Install developer fonts |
 | `make themes` | Install terminal themes |
@@ -99,6 +99,22 @@ breaks whenever an agent changes how it renders. `make herdr` installs a per-age
 integration instead, and the agent reports its own state over the Herdr socket.
 The agents covered are listed in `herdr_integrations` in `defaults.yaml`; run
 `herdr integration install --help` to see every supported target.
+
+`make herdr` is meant to be the single command for Herdr, so it also:
+
+- installs the **herdr agent skill** for every agent in `herdr_skill_agents`,
+  which lets an agent drive the workspace it runs inside — split a pane, run a
+  command in it, read the output back, wait on a sibling agent. `install-claude.sh`
+  installs this too as one of its external skill sources; both are idempotent and
+  the overlap is deliberate, so `make herdr` does not depend on having run the
+  full framework installer.
+- **stows the herdr config**, backing up a hand-written
+  `~/.config/herdr/config.toml` first, because stow refuses to overwrite a real
+  file and aborts the whole invocation if it finds one.
+
+The stow step needs the package to exist in `~/.dotfiles`. A clone predating it
+is reported rather than treated as a failure — run `make dotfiles` to refresh the
+clone, which runs these same steps afterwards.
 
 The hook scripts are versioned with the herdr binary, so they are installed by
 `herdr integration install` rather than checked into the dotfiles repo, where they

--- a/ansible/tasks/herdr.yaml
+++ b/ansible/tasks/herdr.yaml
@@ -103,3 +103,113 @@
     - stow
     - cli
     - herdr
+
+# `make herdr` is meant to deliver everything Herdr needs, not just the state
+# integrations: the skill an agent uses to drive Herdr, and the stowed config.
+#
+# install-claude.sh also installs this skill as one of its external sources, so
+# a full `make` covers it twice. Both are idempotent, and the duplication is
+# deliberate — `make herdr` should stand alone rather than depend on someone
+# having run the whole framework installer.
+- name: Install the herdr agent skill
+  ansible.builtin.shell: |
+    set -euo pipefail
+    export NVM_DIR="{{ ansible_env.HOME }}/.nvm"
+    source "$(brew --prefix nvm)/nvm.sh"
+    npx --yes skills add herdrdev/herdr -g \
+      {% for agent in herdr_skill_agents | default([]) %}-a {{ agent | quote }} {% endfor %}-s herdr -y
+  args:
+    executable: /bin/bash
+  register: herdr_skill_install
+  changed_when: true
+  failed_when: false
+  when: herdr_skill_agents | default([]) | length > 0
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+    - herdr
+
+- name: Warn if the herdr skill could not be installed
+  ansible.builtin.debug:
+    msg: >-
+      Installing the herdr skill exited with rc={{ herdr_skill_install.rc }}.
+      Setup continued because this step is best-effort, matching how the other
+      external skill sources are treated. Re-run `make herdr` later.
+  when:
+    - herdr_skill_install.rc is defined
+    - herdr_skill_install.rc != 0
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+    - herdr
+
+# Stowing needs the package to exist in the managed clone. `make herdr` on its
+# own does not refresh that clone, so report the gap rather than fail: a stale
+# clone predating the herdr package is a normal state, not an error.
+- name: Check the herdr stow package is present in the dotfiles clone
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.dotfiles/herdr"
+  register: herdr_stow_package
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+    - herdr
+
+# Same guard as the pre-stow backup in dotfiles.yaml: stow refuses to overwrite
+# a real file and aborts the whole invocation, so move a hand-written config
+# aside once. A symlink means it is already stowed and nothing happens.
+- name: Back up a hand-written herdr config before stowing
+  ansible.builtin.shell: |
+    set -euo pipefail
+    target="{{ ansible_env.HOME }}/.config/herdr/config.toml"
+    backup="${target}.old"
+    if [ -f "$target" ] && [ ! -L "$target" ] && [ ! -f "$backup" ]; then
+      mv "$target" "$backup"
+      echo moved
+    fi
+  args:
+    executable: /bin/bash
+  register: herdr_config_backup
+  changed_when: herdr_config_backup.stdout != ""
+  when: herdr_stow_package.stat.exists
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+    - herdr
+
+- name: Stow the herdr config package
+  ansible.builtin.command:
+    cmd: stow herdr
+    chdir: "{{ ansible_env.HOME }}/.dotfiles"
+  register: herdr_stow
+  changed_when: herdr_stow.rc == 0
+  failed_when: false
+  when: herdr_stow_package.stat.exists
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+    - herdr
+
+- name: Report that the herdr config could not be stowed yet
+  ansible.builtin.debug:
+    msg: >-
+      {{ ansible_env.HOME }}/.dotfiles does not contain the herdr package yet,
+      so ~/.config/herdr/config.toml was left as-is. The clone predates it —
+      run `make dotfiles` to refresh the clone, which also runs these steps.
+  when: not herdr_stow_package.stat.exists
+  tags:
+    - install
+    - dotfiles
+    - stow
+    - cli
+    - herdr

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -24,6 +24,12 @@ herdr_integrations:
   - claude
   - codex
 
+# Agents that get the herdr skill, which lets an agent drive the workspace it
+# is running inside. Uses skills.sh agent names, not the integration names above.
+herdr_skill_agents:
+  - claude-code
+  - codex
+
 cli_packages_to_remove_if_installed:
   - neofetch
 


### PR DESCRIPTION
> Stacked on #93. Base is `fix/herdr-runs-with-dotfiles-tag`; it retargets to `master` automatically when #93 merges.

## Why

`make herdr` only installed the state integrations. The other two thirds of the setup arrived by unrelated routes:

| Piece | Delivered by | Reachable from `make herdr`? |
|---|---|---|
| State integrations | `make herdr` | yes |
| The herdr agent skill | `install-claude.sh` (curl one-liner, or a full `make`) | **no** |
| The stowed config | `make dotfiles` | **no** |

So the obvious command for setting up Herdr produced a partial result, and nothing said what was missing. On this machine that showed up as the skill being present only because `install-claude.sh` had run, and `~/.config/herdr/config.toml` still being an unmanaged real file.

If the target is named after the tool, it should set the tool up.

## What changed

**Installs the herdr skill** for every agent in the new `herdr_skill_agents` (`claude-code`, `codex`), using the same `npx skills add` invocation `install-claude.sh` uses. That installer still installs it as one of its external sources — both are idempotent, and the duplication is deliberate so this target doesn't depend on someone having run the whole framework installer.

**Stows the herdr config**, with the same backup guard `dotfiles.yaml` uses for `.zshrc` and the ghostty config. Necessary for the reason #91 established: stow refuses to overwrite a real file and aborts the entire invocation when it finds one.

## The one case it can't fully handle

Stowing needs the package present in `~/.dotfiles`, and `make herdr` doesn't refresh that clone. A clone predating the herdr package is a normal state, not an error, so it's reported with the remedy rather than failing the run:

```
~/.dotfiles does not contain the herdr package yet, so ~/.config/herdr/config.toml
was left as-is. The clone predates it — run `make dotfiles` to refresh the clone,
which also runs these steps.
```

That is the situation on my machine right now: `~/.dotfiles` is at `370309e` while `origin/main` has the package.

## Verification

`--syntax-check` passes. `--list-tasks --tags herdr` now selects all eleven tasks:

```
Check whether herdr is installed
Report herdr integration status
Install herdr agent state integrations
Warn if a herdr integration could not be installed
Note that herdr is not installed
Install the herdr agent skill
Warn if the herdr skill could not be installed
Check the herdr stow package is present in the dotfiles clone
Back up a hand-written herdr config before stowing
Stow the herdr config package
Report that the herdr config could not be stowed yet
```

The templated skill command was rendered through Ansible to confirm the loop produces valid arguments:

```
npx --yes skills add herdrdev/herdr -g \
  -a claude-code -a codex -s herdr -y
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)