### PR TITLE
fix(herdr): repair a wiped hook registration instead of skipping it

### DIFF
--- a/ansible/tasks/herdr.yaml
+++ b/ansible/tasks/herdr.yaml
@@ -34,36 +34,29 @@
     - cli
     - herdr
 
-- name: Report herdr integration status
-  ansible.builtin.command: herdr integration status
-  register: herdr_integration_status
-  changed_when: false
-  failed_when: false
-  when: herdr_binary.rc == 0
-  tags:
-    - install
-    - dotfiles
-    - stow
-    - cli
-    - herdr
-
 # `herdr integration install <agent>` refuses to run until the agent's own
 # config directory exists, so on a fresh machine this can legitimately have
 # nothing to do yet. Treated as best-effort for the same reason install-claude.sh
 # is: an optional convenience should never abort a whole `make` run.
+#
+# This deliberately runs on every converge rather than gating on
+# `herdr integration status`. That status describes the hook *script* on disk,
+# not its registration in ~/.claude/settings.json — so after the settings.json
+# copy above drops the SessionStart entry, status still reports "current (v7)"
+# while the hook is inert. Gating on it made this repair a no-op in precisely
+# the situation it exists to fix.
+#
+# `herdr integration install` is idempotent by design: it reports "ensured
+# <agent> settings" and converges to a single registration however many times it
+# runs. The cost of running it unconditionally is a task that always reports
+# changed, which matches how install-claude.sh is handled in dotfiles.yaml.
 - name: Install herdr agent state integrations
   ansible.builtin.command: "herdr integration install {{ item }}"
   loop: "{{ herdr_integrations | default([]) }}"
   register: herdr_integration_install
   changed_when: true
   failed_when: false
-  # The search expression must stay quoted: the `: ` inside it would otherwise
-  # make YAML parse this list entry as a mapping, which Ansible then treats as
-  # unconditionally true and the task loses its idempotency.
-  when:
-    - herdr_binary.rc == 0
-    - herdr_integration_status.stdout is defined
-    - "herdr_integration_status.stdout is search(item ~ ': not installed')"
+  when: herdr_binary.rc == 0
   tags:
     - install
     - dotfiles


### PR DESCRIPTION
## The bug

#93 made the herdr repair run under the `dotfiles` tag, so it would follow the settings.json copy that drops the Claude `SessionStart` entry. It runs now — and does nothing.

The task gated on `herdr integration status` reporting `not installed`. That status describes the hook **script on disk**, not its registration in `~/.claude/settings.json`. Those come apart exactly when the repair is needed:

```
$ grep -c herdr-agent-state ~/.claude/settings.json
0                                    # registration wiped, hook inert
$ herdr integration status | grep claude
claude: current (v7)                 # ...but status says all is well
```

So the gate evaluated false and skipped the repair, in precisely the situation the task exists to fix. Every pane fell back to screen detection with nothing reporting a problem.

## Verification

Reproduced in a throwaway `HOME` with the hook script present and the registration absent — the real state on my machine after `make dotfiles`:

| Step | Result |
|---|---|
| `herdr integration status` | `claude: current (v7)` — the gate skips |
| `herdr integration install claude` | `ensured claude settings`, registration count **0 → 1** |
| run it a second time | count stays **1** |

## The fix

Run it unconditionally. `herdr integration install` is idempotent by design — it reports "ensured `<agent>` settings" and converges to a single registration however many times it runs, as the third row above shows.

The cost is a task that always reports changed. That matches how `install-claude.sh` is already handled in `dotfiles.yaml`, and it is the right trade against a repair that silently does nothing.

Also drops the now-dead status task and its registered variable, since nothing reads it any more.

`--syntax-check` passes; `--list-tasks --tags herdr` still selects the remaining ten tasks in order.

## Note on what this does not cover

This restores the registration. Sessions already running when it is restored still report nothing, because the hook is a `SessionStart` hook — those panes need a restart, same as the initial install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)